### PR TITLE
Features/remove base 64 enconding and decoding

### DIFF
--- a/Src/Clawrenceks.HttpCachingHandler.Abstractions/Properties/AssemblyInfo.cs
+++ b/Src/Clawrenceks.HttpCachingHandler.Abstractions/Properties/AssemblyInfo.cs
@@ -6,12 +6,8 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Clawrenceks.HttpCachingHandler.Abstractions")]
 [assembly: AssemblyDescription("Abstractions for Clawrenceks.HttpCachingHandler")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Chris Lawrence")]
 [assembly: AssemblyProduct("Clawrenceks.HttpCachingHandler.Abstractions")]
-[assembly: AssemblyCopyright("")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Src/Clawrenceks.HttpCachingHandler/Extensions/HttpRequestMessageExtensions.cs
+++ b/Src/Clawrenceks.HttpCachingHandler/Extensions/HttpRequestMessageExtensions.cs
@@ -7,10 +7,14 @@ namespace Clawrenceks.HttpCachingHandler.Extensions
         public static bool ShouldBypassPrivateCache(this HttpRequestMessage request)
         {
             if (request?.Headers?.CacheControl?.NoCache == true)
-            return true;
+            {
+                return true;
+            }
 
             if (request?.Method != HttpMethod.Get)
+            {
                 return true;
+            }
 
             return false;
         }

--- a/Src/Clawrenceks.HttpCachingHandler/HttpCachingHandler.cs
+++ b/Src/Clawrenceks.HttpCachingHandler/HttpCachingHandler.cs
@@ -46,11 +46,10 @@ namespace Clawrenceks.HttpCachingHandler
             }
 
             var cachedResponse = _cache.Get(requestUrl);
-            var decodedCachedResponse = Convert.FromBase64String(cachedResponse);
 
             var httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = new ByteArrayContent(decodedCachedResponse)
+                Content = new StringContent(cachedResponse)
             };
 
             return httpResponse;           
@@ -73,15 +72,14 @@ namespace Clawrenceks.HttpCachingHandler
                 }
             }
 
-            var responseContent = await response.Content.ReadAsByteArrayAsync();
-            var base64Content = Convert.ToBase64String(responseContent);
+            var responseContent = await response.Content.ReadAsStringAsync();
 
             var maxAgeHeader = response.Headers.CacheControl.MaxAge.Value.TotalSeconds;
 
             var eTag = ParseReponseEtag(response);
 
             _cache.Add(requestUrl,
-                base64Content,
+                responseContent,
                 TimeSpan.FromSeconds(maxAgeHeader),
                 eTag);
         }

--- a/Src/Clawrenceks.HttpCachingHandler/Properties/AssemblyInfo.cs
+++ b/Src/Clawrenceks.HttpCachingHandler/Properties/AssemblyInfo.cs
@@ -6,12 +6,8 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Clawrenceks.HttpCachingHandler")]
 [assembly: AssemblyDescription("A Lightweight HttpClient Handler to allow caching of http requests to be built into a HttpClient request pipeline")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Chris Lawrence")]
 [assembly: AssemblyProduct("Clawrenceks.HttpCachingHandler")]
-[assembly: AssemblyCopyright("")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Tests/Clawrenceks.HttpCachingHandler.UnitTests/HttpCachingHandlerTests.cs
+++ b/Tests/Clawrenceks.HttpCachingHandler.UnitTests/HttpCachingHandlerTests.cs
@@ -242,7 +242,7 @@ namespace Clawrenceks.HttpCachingHandler.UnitTests
                 .Returns(false);
 
             _mockResponseCache.Setup(c => c.Get(It.Is<string>(s => s == request.RequestUri.AbsoluteUri)))
-                .Returns(Convert.ToBase64String(Encoding.ASCII.GetBytes("My cached response content")));
+                .Returns("My cached response content");
 
             //Act
             await sut.SendAsync(request, new CancellationToken());
@@ -269,7 +269,7 @@ namespace Clawrenceks.HttpCachingHandler.UnitTests
                 .Returns(false);
 
             _mockResponseCache.Setup(c => c.Get(It.Is<string>(s => s == request.RequestUri.AbsoluteUri)))
-                .Returns(Convert.ToBase64String(Encoding.ASCII.GetBytes("My cached response content")));
+                .Returns("My cached response content");
 
             //Act
             var result = await sut.SendAsync(request, new CancellationToken());
@@ -296,7 +296,7 @@ namespace Clawrenceks.HttpCachingHandler.UnitTests
                 .Returns(false);
 
             _mockResponseCache.Setup(c => c.Get(It.Is<string>(s => s == request.RequestUri.AbsoluteUri)))
-                .Returns(Convert.ToBase64String(Encoding.ASCII.GetBytes("My cached response content")));
+                .Returns("My cached response content");
 
             //Act
             var result = await sut.SendAsync(request, new CancellationToken());
@@ -519,9 +519,7 @@ namespace Clawrenceks.HttpCachingHandler.UnitTests
             await sut.SendAsync(request, new CancellationToken());
 
             //Assert
-            var contentBytes = Encoding.ASCII.GetBytes("My Example Reponse");
-            var encodedContent = Convert.ToBase64String(contentBytes);
-            _mockResponseCache.Verify(c => c.Add(It.IsAny<string>(), It.Is<string>(s => s == encodedContent), It.IsAny<TimeSpan>(), null), Times.Once);
+            _mockResponseCache.Verify(c => c.Add(It.IsAny<string>(), It.Is<string>(s => s == "My Example Reponse"), It.IsAny<TimeSpan>(), null), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
Removed the Base64 encoding and decoding from the HttpClientHandler. This now just works with strings. leaving any encoding and decoding to the caching implementation provided.