### PR TITLE
Resolved issue preventing previously expired cache entries from being updated

### DIFF
--- a/Src/Clawrenceks.HttpCachingHandler/HttpCachingHandler.cs
+++ b/Src/Clawrenceks.HttpCachingHandler/HttpCachingHandler.cs
@@ -42,7 +42,9 @@ namespace Clawrenceks.HttpCachingHandler
                     request.Headers.IfNoneMatch.TryParseAdd(eTag);
                 }
 
-                return await base.SendAsync(request, cancellationToken);
+                var response = await base.SendAsync(request, cancellationToken);
+                await ProcessResponseCaching(response);
+                return response;
             }
 
             var cachedResponse = _cache.Get(requestUrl);


### PR DESCRIPTION
Resolved an issue which meant that a cached item was never updated when the cache contained an expired reponse for the request