### PR TITLE
Resolved an issue causing requests to incorrectly return a 304 result

### DIFF
--- a/Src/Clawrenceks.HttpCachingHandler/HttpCachingHandler.cs
+++ b/Src/Clawrenceks.HttpCachingHandler/HttpCachingHandler.cs
@@ -44,6 +44,12 @@ namespace Clawrenceks.HttpCachingHandler
 
                 var response = await base.SendAsync(request, cancellationToken);
                 await ProcessResponseCaching(response);
+                
+                if (response.StatusCode == HttpStatusCode.NotModified)
+                {
+                    response.StatusCode = HttpStatusCode.OK;
+                }
+
                 return response;
             }
 


### PR DESCRIPTION
Resolved an issue which caused the status code of responses to remain as 304 when the HttpRequest returned a 304 Not Modified result, rather than being set to a 200 OK result as required.